### PR TITLE
Fix crash if permissions disabled

### DIFF
--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2996,9 +2996,13 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
         //CGEventMaskBit(kCGEventKeyDown);
         eventTap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, 0, eventMask, CGEventCallback, NULL);
 
-        CGEventTapEnable(eventTap, true);
-        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
-        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, kCFRunLoopCommonModes);
+        if (eventTap != nil) {
+            CGEventTapEnable(eventTap, true);
+            runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
+            CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, kCFRunLoopCommonModes);
+        } else {
+            NSLog(@"Could not create CGEventTap. Allow Jitouch in System Preferences -> Privacy -> Accessibility.");
+        }
 
         gestureWindow = [[GestureWindow alloc] init];
         sizeHistoryDict = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Recent versions of macOS require Security/Accessibility permissions for CGEventTapCreate, causing Jitouch to crash if the Jitouch binary is run and those permissions aren't enabled.

This commit prevents calling CGEventTapEnable with a null eventTap. Instead of crashing, a prompt is automatically shown by macOS to allow Jitouch in System Preferences, allowing the permissions to be granted.

Pull request submitted upstream: [#2](https://github.com/sukolsak/jitouch/pull/2)