### PR TITLE
Cleanup MTDevice reloading on wakeup

### DIFF
--- a/jitouch/Jitouch/Gesture.h
+++ b/jitouch/Jitouch/Gesture.h
@@ -11,6 +11,8 @@
 
 - (id)init;
 
+- (void)reload;
+
 @end
 
 void turnOffGestures(void);

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2898,6 +2898,7 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
 CFArrayRef deviceList;
 
 - (id)init {
+    NSLog(@"Initializing.");
     if (self = [super init]) {
         me = self;
 
@@ -3015,6 +3016,7 @@ CFArrayRef deviceList;
 }
 
 - (void)reload {
+    NSLog(@"Reloading gestures.");
     for (CFIndex i = 0; i < CFArrayGetCount(deviceList); i++) {
         MTDeviceRef device = (MTDeviceRef)CFArrayGetValueAtIndex(deviceList, i);
         int familyID;

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -1,4 +1,3 @@
-
 //
 //  Gesture.m
 //  Jitouch

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2895,7 +2895,7 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
 }
 
 #pragma mark - Init
-CFArrayRef deviceList;
+CFMutableArrayRef deviceList;
 
 - (id)init {
     NSLog(@"Initializing.");
@@ -3025,10 +3025,13 @@ CFArrayRef deviceList;
         MTDeviceGetDeviceID(device, &deviceID);
         NSLog(@"stop device %li %"PRIu64" family %d %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
         if (familyID >= 98) {
+            MTUnregisterContactFrameCallback(device, trackpadCallback);
+            MTUnregisterContactFrameCallback(device, magicMouseCallback);
             MTDeviceStop(device);
         }
-        MTDeviceRelease(device);
     }
+    CFRelease(deviceList);
+    sleep(1);
     deviceList = MTDeviceCreateList();
     for (CFIndex i = 0; i < CFArrayGetCount(deviceList); i++) {
         MTDeviceRef device = (MTDeviceRef)CFArrayGetValueAtIndex(deviceList, i);
@@ -4011,10 +4014,7 @@ static void trackpadRecognizerTwo(const Finger *data, int nFingers, double times
 #pragma mark -
 
 - (void) dealloc {
-    for (CFIndex i = 0; i < CFArrayGetCount(deviceList); i++) {
-        MTDeviceRef device = (MTDeviceRef)CFArrayGetValueAtIndex(deviceList, i);
-        MTDeviceRelease(device);
-    }
+    CFRelease(deviceList);
     [super dealloc];
 }
 

--- a/jitouch/Jitouch/JitouchAppDelegate.h
+++ b/jitouch/Jitouch/JitouchAppDelegate.h
@@ -19,6 +19,8 @@
 
 @property (assign) IBOutlet NSWindow *window;
 
+- (void)reload;
+
 @end
 
 extern CursorWindow *cursorWindow;

--- a/jitouch/Jitouch/JitouchAppDelegate.m
+++ b/jitouch/Jitouch/JitouchAppDelegate.m
@@ -252,7 +252,11 @@ void languageChanged(CFNotificationCenterRef center, void *observer, CFStringRef
 }
 
 - (void)wokeUp:(NSNotification *)aNotification {
-    NSLog(@"Woke up. Reloading gestures.");
+    NSLog(@"Woke up.");
+    [self reload];
+}
+
+- (void)reload {
     [gesture reload];
 }
 

--- a/jitouch/Jitouch/JitouchAppDelegate.m
+++ b/jitouch/Jitouch/JitouchAppDelegate.m
@@ -252,25 +252,8 @@ void languageChanged(CFNotificationCenterRef center, void *observer, CFStringRef
 }
 
 - (void)wokeUp:(NSNotification *)aNotification {
-    //restart outselves
-    NSString *killArg1AndOpenArg2Script = @"kill -9 $1 \n open \"$2\"";
-
-    //NSTask needs its arguments to be strings
-    NSString *ourPID = [NSString stringWithFormat:@"%d",
-                        [[NSProcessInfo processInfo] processIdentifier]];
-
-    //this will be the path to the .app bundle,
-    //not the executable inside it; exactly what `open` wants
-    NSString * pathToUs = [[NSBundle mainBundle] bundlePath];
-
-    NSArray *shArgs = [NSArray arrayWithObjects:@"-c", // -c tells sh to execute the next argument, passing it the remaining arguments.
-                       killArg1AndOpenArg2Script,
-                       @"", //$0 path to script (ignored)
-                       ourPID, //$1 in restartScript
-                       pathToUs, //$2 in the restartScript
-                       nil];
-    NSTask *restartTask = [NSTask launchedTaskWithLaunchPath:@"/bin/sh" arguments:shArgs];
-    [restartTask waitUntilExit]; //wait for killArg1AndOpenArg2Script to finish
+    NSLog(@"Woke up. Reloading gestures.");
+    [gesture reload];
 }
 
 #pragma mark -

--- a/jitouch/Jitouch/main.m
+++ b/jitouch/Jitouch/main.m
@@ -6,8 +6,26 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "signal.h"
+#include "JitouchAppDelegate.h"
 
 int main(int argc, const char * argv[])
 {
+    // Trap SIGHUP and do reload
+    // see https://stackoverflow.com/questions/50225548/trap-sigint-in-cocoa-macos-application
+    // see https://www.mikeash.com/pyblog/friday-qa-2011-04-01-signal-handling.html
+    // see https://fossies.org/linux/HandBrake/macosx/main.m
+    dispatch_source_t source = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGHUP, 0, dispatch_get_global_queue(0, 0));
+    dispatch_source_set_event_handler(source, ^{
+        NSLog(@"Received SIGHUP.");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [((JitouchAppDelegate*)[NSApp delegate]) reload];
+        });
+    });
+    dispatch_resume(source);
+
+    // Ignore the SIGHUP signal because we handle it.
+    signal(SIGHUP, SIG_IGN);
+
     return NSApplicationMain(argc, argv);
 }

--- a/jitouch/Jitouch/main.m
+++ b/jitouch/Jitouch/main.m
@@ -3,6 +3,7 @@
 //  Jitouch
 //
 //  Copyright 2021 Supasorn Suwajanakorn and Sukolsak Sakshuwong. All rights reserved.
+//  Modified work Copyright 2021 Aaron Kollasch. All rights reserved.
 //
 
 #import <Cocoa/Cocoa.h>


### PR DESCRIPTION
Jitouch must reload its MTDevices when the system wakes from sleep. The old way of doing this is to kill and restart the Jitouch process. While this ensures a full reload, it is inelegant. I've also seen reliability issues that require a manual restart.

This PR adds a `reload()` function to `jitouch/Jitouch/JitouchAppDelegate.m` that reloads the MTDevices and is called upon wake from sleep. Reloading can also be triggered by sending SIGHUP to the Jitouch process, for example with `killall -HUP Jitouch`.

For signal handling examples see:
- https://stackoverflow.com/questions/50225548/trap-sigint-in-cocoa-macos-application
- https://www.mikeash.com/pyblog/friday-qa-2011-04-01-signal-handling.html
- https://fossies.org/linux/HandBrake/macosx/main.m

Automatic reloading on wake has been tested with the built-in trackpad, but it is possible that some Magic Trackpad and Magic Mouse related code (specifically, the [device-added notifications](https://github.com/aaronkollasch/jitouch/blob/ed0c5e11ab2c6c673e3bad38299f39b07188db0c/jitouch/Jitouch/Gesture.m#L2947), [updateDevicesMM](https://github.com/aaronkollasch/jitouch/blob/ed0c5e11ab2c6c673e3bad38299f39b07188db0c/jitouch/Jitouch/Gesture.m#L2541) and [updateDevicesMT](https://github.com/aaronkollasch/jitouch/blob/ed0c5e11ab2c6c673e3bad38299f39b07188db0c/jitouch/Jitouch/Gesture.m#L600)) will need to be reloaded as well (so testing with those devices is needed). However, updateDevicesMM and updateDevicesMT appear unused, the notifications are not essential functionality, and all other parts of MT and MM support should function properly.