### PR TITLE
Fix UI freeze if permissions are disabled while Jitouch is running

### DIFF
--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2659,6 +2659,15 @@ static void magicTrackpadRemoved(void* refCon, io_iterator_t iterator) {
 #pragma mark - CGEventCallback
 
 static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon) {
+    if (type == kCGEventTapDisabledByTimeout) {
+        NSLog(@"kCGEventTapDisabledByTimeout; exiting.");
+        exit(1);
+    }
+
+    if (type == kCGEventTapDisabledByUserInput) {
+        return event;
+    }
+
     if (trackpadNFingers == 2 && twoFingersDistance < 0.3f && (type == kCGEventLeftMouseDown || type == kCGEventLeftMouseUp)) {
         return NULL;
     }


### PR DESCRIPTION
Issue #5 describes an indefinite UI non-responsiveness that occurs if Accessibility permissions are revoked. This is due to Jitouch's `CGEventTap` callback that receives user input events but cannot pass them along due to a lack of permissions.

After a delay, the OS normally detects the CGEventTap has timed out and sends a `kCGEventTapDisabledByTimeout` event to Jitouch's `CGEventCallback`. However, this event was ignored, allowing Jitouch to continue dropping all mouse and keyboard events.

Now, if CGEventCallback receives a kCGEventTapDisabledByTimeout event, it will trigger Jitouch to exit(). CGEventCallback will also handle kCGEventTapDisabledByUserInput gracefully, by returning the input event unchanged.

Fixes #5

See:
- https://developer.apple.com/documentation/coregraphics/1455445-cgeventtapenable
- https://developer.apple.com/documentation/coregraphics/cgeventtype?language=objc
- http://mirror.informatimago.com/next/developer.apple.com/documentation/Carbon/Reference/QuartzEventServicesRef/QuartzEventServicesRef.pdf