### PR TITLE
Reduce the minimum index-ring distance for character gestures

### DIFF
--- a/prefpane/Base.lproj/JitouchPref.xib
+++ b/prefpane/Base.lproj/JitouchPref.xib
@@ -1400,7 +1400,7 @@ Gw
                     <slider toolTip="Distance between your Index and Ring fingers" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="547">
                         <rect key="frame" x="70" y="286" width="156" height="25"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <sliderCell key="cell" state="on" baseWritingDirection="leftToRight" alignment="left" minValue="25" maxValue="45" doubleValue="33" tickMarkPosition="below" numberOfTickMarks="10" sliderType="linear" id="550"/>
+                        <sliderCell key="cell" state="on" baseWritingDirection="leftToRight" alignment="left" minValue="10" maxValue="45" doubleValue="33" tickMarkPosition="below" numberOfTickMarks="10" sliderType="linear" id="550"/>
                         <connections>
                             <action selector="change:" target="597" id="617"/>
                         </connections>


### PR DESCRIPTION
Reduces the minimum from 25 to 10 – this is likely "too small" in most cases, but allows more room for customization.

Fixes #15 