### PR TITLE
Fix UI freeze for some trackpad gestures

### DIFF
--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2670,8 +2670,12 @@ static void magicTrackpadRemoved(void* refCon, io_iterator_t iterator) {
 #pragma mark - CGEventCallback
 
 static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon) {
-    if (trackpadNFingers == 2 && twoFingersDistance < 0.3f && (type == kCGEventLeftMouseDown || type == kCGEventLeftMouseUp)) {
+    if (trackpadNFingers == 2 && twoFingersDistance < 0.3f && type == kCGEventLeftMouseDown) {
+        if (logLevel >= LOG_LEVEL_DEBUG)
+            dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{NSLog(@"Suppressed Mouse%d with %d fingers %f", type, trackpadNFingers, twoFingersDistance);});
         return NULL;
+    } else if (logLevel >= LOG_LEVEL_DEBUG && (type == kCGEventLeftMouseDown || type == kCGEventLeftMouseUp)) {
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{NSLog(@"Did not suppress Mouse%d with %d fingers %f", type, trackpadNFingers, twoFingersDistance);});
     }
 
     if (type == kCGEventLeftMouseDown || type == kCGEventRightMouseDown) {

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -2944,7 +2944,7 @@ static CGEventRef CGEventCallback(CGEventTapProxy proxy, CGEventType type, CGEve
 CFMutableArrayRef deviceList;
 
 - (id)init {
-    NSLog(@"Initializing.");
+    if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Initializing.");
     if (self = [super init]) {
         me = self;
 
@@ -2962,7 +2962,7 @@ CFMutableArrayRef deviceList;
                 MTDeviceGetFamilyID(device, &familyID);
                 uint64_t deviceID = 0;
                 MTDeviceGetDeviceID(device, &deviceID);
-                NSLog(@"Start device %li %"PRIu64" family %d (%s)", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
+                if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Start device %li %"PRIu64" family %d (%s)", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
                 if (familyID == 98 || familyID == 99 || familyID == 100  // built-in trackpad
                     || familyID == 101 // retina mbp
                     || familyID == 102 // retina macbook with the Force Touch trackpad (2015)
@@ -2986,7 +2986,7 @@ CFMutableArrayRef deviceList;
                     MTRegisterContactFrameCallback(device, trackpadCallback);
                     MTDeviceStart(device, 0);
                 }
-                NSLog(@"Device %li %"PRIu64" family %d is %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
+                if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Device %li %"PRIu64" family %d is %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
             }
             //CFRelease((CFMutableArrayRef)deviceList); // DO NOT release. It'll crash.
         }
@@ -3059,20 +3059,20 @@ CFMutableArrayRef deviceList;
 }
 
 - (void)reload {
-    NSLog(@"Reloading gestures.");
+    if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Reloading gestures.");
     for (CFIndex i = 0; i < CFArrayGetCount(deviceList); i++) {
         MTDeviceRef device = (MTDeviceRef)CFArrayGetValueAtIndex(deviceList, i);
         int familyID;
         MTDeviceGetFamilyID(device, &familyID);
         uint64_t deviceID = 0;
         MTDeviceGetDeviceID(device, &deviceID);
-        NSLog(@"Stop device %li %"PRIu64" family %d (%s)", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
+        if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Stop device %li %"PRIu64" family %d (%s)", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
         if (familyID >= 98) {
             MTUnregisterContactFrameCallback(device, trackpadCallback);
             MTUnregisterContactFrameCallback(device, magicMouseCallback);
             MTDeviceStop(device);
         }
-        NSLog(@"Device %li %"PRIu64" family %d is %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
+        if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Device %li %"PRIu64" family %d is %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
     }
     CFRelease(deviceList);
     sleep(1);
@@ -3083,7 +3083,7 @@ CFMutableArrayRef deviceList;
         MTDeviceGetFamilyID(device, &familyID);
         uint64_t deviceID = 0;
         MTDeviceGetDeviceID(device, &deviceID);
-        NSLog(@"Start device %li %"PRIu64", family %d (%s)", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
+        if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Start device %li %"PRIu64", family %d (%s)", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
         if (familyID == 98 || familyID == 99 || familyID == 100  // built-in trackpad
             || familyID == 101 // retina mbp
             || familyID == 102 // retina macbook with the Force Touch trackpad (2015)
@@ -3107,7 +3107,7 @@ CFMutableArrayRef deviceList;
             MTRegisterContactFrameCallback(device, trackpadCallback);
             MTDeviceStart(device, 0);
         }
-        NSLog(@"Device %li %"PRIu64" family %d is %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
+        if (logLevel >= LOG_LEVEL_INFO) NSLog(@"Device %li %"PRIu64" family %d is %s", (long)i, deviceID, familyID, (MTDeviceIsRunning(device)) ? "running" : "not running");
     }
 }
 

--- a/jitouch/Jitouch/Settings.h
+++ b/jitouch/Jitouch/Settings.h
@@ -20,6 +20,13 @@ extern NSMutableDictionary *recognitionMap;
 extern float clickSpeed;
 extern float stvt;
 extern int enAll;
+extern int logLevel;
+typedef enum log_level_t : int {
+    LOG_LEVEL_ERROR = -1,
+    LOG_LEVEL_DEFAULT = 0,
+    LOG_LEVEL_INFO = 1,
+    LOG_LEVEL_DEBUG = 2,
+} log_level_t;
 
 //Trackpad
 extern int enTPAll;

--- a/jitouch/Jitouch/Settings.m
+++ b/jitouch/Jitouch/Settings.m
@@ -27,6 +27,7 @@ NSMutableDictionary *recognitionMap;
 float clickSpeed;
 float stvt;
 int enAll;
+int logLevel;
 
 //Trackpad
 int enTPAll;
@@ -171,6 +172,7 @@ static int notSynchronize;
     [Settings setKey:@"Sensitivity" withFloat:4.6666];
     [Settings setKey:@"ShowIcon" withInt:1];
     [Settings setKey:@"Revision" withInt:kCurrentRevision];
+    [Settings setKey:@"LogLevel" withInt:0];
 
     //Trackpad
     [Settings setKey:@"enTPAll" withInt:1];
@@ -210,6 +212,7 @@ static int notSynchronize;
     enAll = [[settings objectForKey:@"enAll"] intValue];
     clickSpeed = [[settings objectForKey:@"ClickSpeed"] floatValue];
     stvt = [[settings objectForKey:@"Sensitivity"] floatValue];
+    logLevel = [[settings objectForKey:@"LogLevel"] intValue];
 
     //Trackpad
     enTPAll = [[settings objectForKey:@"enTPAll"] intValue];

--- a/prefpane/Base.lproj/JitouchPref.xib
+++ b/prefpane/Base.lproj/JitouchPref.xib
@@ -11,6 +11,7 @@
             <connections>
                 <outlet property="_window" destination="12" id="26"/>
                 <outlet property="cbShowIcon" destination="183" id="274"/>
+                <outlet property="loggingMode" destination="lcf-GP-iMM" id="yGL-nm-LbE"/>
                 <outlet property="mainTabView" destination="100" id="275"/>
                 <outlet property="scAll" destination="365" id="377"/>
                 <outlet property="scrollView" destination="133" id="279"/>
@@ -773,6 +774,36 @@ DQ
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="jitouchicon" id="744"/>
                                         </imageView>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eai-SA-Zdz">
+                                            <rect key="frame" x="204" y="80" width="109" height="16"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Logging Mode" id="6Xl-zX-oGa">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lcf-GP-iMM">
+                                            <rect key="frame" x="319" y="73" width="94" height="25"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <popUpButtonCell key="cell" type="push" title="Default" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="gpw-XY-QI4" id="PGl-y5-y37">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" id="WrM-zS-FSz">
+                                                    <items>
+                                                        <menuItem title="Default" tag="0" state="on" id="gpw-XY-QI4"/>
+                                                        <menuItem title="Quiet" tag="-1" id="bze-kv-zjA"/>
+                                                        <menuItem title="Info" tag="1" id="aux-8X-cLx"/>
+                                                        <menuItem title="Debug" tag="2" id="14r-4E-Iof">
+                                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="change:" target="-2" id="sXj-3V-hbe"/>
+                                            </connections>
+                                        </popUpButton>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/prefpane/JitouchPref.h
+++ b/prefpane/JitouchPref.h
@@ -19,6 +19,7 @@
     IBOutlet NSButton *cbShowIcon;
     IBOutlet NSTabView *mainTabView;
     IBOutlet NSScrollView *scrollView;
+    IBOutlet NSPopUpButton *loggingMode;
 
     KeyTextView *keyTextView;
 }

--- a/prefpane/JitouchPref.m
+++ b/prefpane/JitouchPref.m
@@ -65,6 +65,9 @@ CFMachPortRef eventTap;
     } else if (sender == sdSensitivity) {
         stvt = [sender floatValue];
         [Settings setKey:@"Sensitivity" withFloat:[sender floatValue]];
+    } else if (sender == loggingMode) {
+        logLevel = (int)[[sender selectedItem] tag];
+        [Settings setKey:@"LogLevel" withInt:(int)[[sender selectedItem] tag]];
     }
     [Settings noteSettingsUpdated];
 }

--- a/prefpane/Settings.h
+++ b/prefpane/Settings.h
@@ -22,6 +22,13 @@ extern NSMutableDictionary *recognitionMap;
 extern float clickSpeed;
 extern float stvt;
 extern int enAll;
+extern int logLevel;
+typedef enum log_level_t : int {
+    LOG_LEVEL_ERROR = -1,
+    LOG_LEVEL_DEFAULT = 0,
+    LOG_LEVEL_INFO = 1,
+    LOG_LEVEL_DEBUG = 2,
+} log_level_t;
 
 //Trackpad
 extern int enTPAll;

--- a/prefpane/Settings.m
+++ b/prefpane/Settings.m
@@ -20,6 +20,7 @@ NSMutableDictionary *recognitionMap;
 float clickSpeed;
 float stvt;
 int enAll;
+int logLevel;
 
 //Trackpad
 int enTPAll;
@@ -181,6 +182,7 @@ static int notSynchronize;
     [Settings setKey:@"Sensitivity" withFloat:4.6666];
     [Settings setKey:@"ShowIcon" withInt:1];
     [Settings setKey:@"Revision" withInt:kCurrentRevision];
+    [Settings setKey:@"LogLevel" withInt:0];
 
     //Trackpad
     [Settings setKey:@"enTPAll" withInt:1];
@@ -222,6 +224,7 @@ static int notSynchronize;
     enAll = [[settings objectForKey:@"enAll"] intValue];
     clickSpeed = [[settings objectForKey:@"ClickSpeed"] floatValue];
     stvt = [[settings objectForKey:@"Sensitivity"] floatValue];
+    logLevel = [[settings objectForKey:@"LogLevel"] intValue];
 
     //Trackpad
     enTPAll = [[settings objectForKey:@"enTPAll"] intValue];


### PR DESCRIPTION
This PR addresses UI freezes related to some trackpad gestures.
- `doCommand` dispatches asynchronously, allowing callbacks to return faster.
- `CGEventCallback` no longer suppresses MouseUp events when two fingers are held down, allowing any MouseDown events created while performing a gesture to release. MouseDown events are still suppressed to prevent one-fix-one-tap gestures from sending MouseDown events.
- If `kCGEventTapDisabledByTimeout` is received by `CGEventCallback`, recreating the EventTap is dispatched asynchronously.
- Adds a setting for log verbosity level. This can be replaced by the [logging API](https://developer.apple.com/documentation/os/logging?language=objc) if the macOS target is increased to 10.12 at some point.

Fixes #20