### PR TITLE
Fix gesture preview crash in command sheet

### DIFF
--- a/prefpane/GestureTableView.m
+++ b/prefpane/GestureTableView.m
@@ -17,22 +17,8 @@
     if (attachedWindow) {
         [gesturePreviewView stopTimer];
         gesturePreviewView = nil;
-        NSWindow *localAttachedWindow = attachedWindow;
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            float alpha = 1.0;
-            for (int i = 0; i < 10; i++) {
-                alpha -= 0.1;
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [localAttachedWindow setAlphaValue:alpha];
-                });
-                usleep(20 * 1000);
-            }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[self window] removeChildWindow:localAttachedWindow];
-                [localAttachedWindow orderOut:self];
-                [localAttachedWindow release];
-            });
-        });
+        [attachedWindow orderOut:self];
+        [[self window] removeChildWindow:attachedWindow];
         attachedWindow = nil;
     }
     saveRowIndex = -1;

--- a/prefpane/MAAttachedWindow.m
+++ b/prefpane/MAAttachedWindow.m
@@ -337,7 +337,7 @@
                                  flipped:NO
                           drawingHandler:???];
  */
-    return [NSColor lightGrayColor];  // Return static color for now.
+    return _MABackgroundColor;  // Return static color for now.
 }
 
 

--- a/prefpane/MagicMouseTab.m
+++ b/prefpane/MagicMouseTab.m
@@ -103,22 +103,8 @@
     if (attachedWindow) {
         [gesturePreviewView stopTimer];
         gesturePreviewView = nil;
-        NSWindow *localAttachedWindow = attachedWindow;
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            float alpha = 1.0;
-            for (int i = 0; i < 10; i++) {
-                alpha -= 0.1;
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [localAttachedWindow setAlphaValue:alpha];
-                });
-                usleep(20 * 1000);
-            }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [window removeChildWindow:localAttachedWindow];
-                [localAttachedWindow orderOut:self];
-                [localAttachedWindow release];
-            });
-        });
+        [attachedWindow orderOut:self];
+        [window removeChildWindow:attachedWindow];
         attachedWindow = nil;
     }
     saveRowIndex = -1;

--- a/prefpane/RecognitionTab.m
+++ b/prefpane/RecognitionTab.m
@@ -91,22 +91,8 @@
     if (attachedWindow) {
         [gesturePreviewView stopTimer];
         gesturePreviewView = nil;
-        NSWindow *localAttachedWindow = attachedWindow;
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            float alpha = 1.0;
-            for (int i = 0; i < 10; i++) {
-                alpha -= 0.1;
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [localAttachedWindow setAlphaValue:alpha];
-                });
-                usleep(20 * 1000);
-            }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [window removeChildWindow:localAttachedWindow];
-                [localAttachedWindow orderOut:self];
-                [localAttachedWindow release];
-            });
-        });
+        [attachedWindow orderOut:self];
+        [window removeChildWindow:attachedWindow];
         attachedWindow = nil;
     }
     saveRowIndex = -1;

--- a/prefpane/TrackpadTab.m
+++ b/prefpane/TrackpadTab.m
@@ -114,22 +114,8 @@
     if (attachedWindow) {
         [gesturePreviewView stopTimer];
         gesturePreviewView = nil;
-        NSWindow *localAttachedWindow = attachedWindow;
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            float alpha = 1.0;
-            for (int i = 0; i < 10; i++) {
-                alpha -= 0.1;
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [localAttachedWindow setAlphaValue:alpha];
-                });
-                usleep(20 * 1000);
-            }
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [window removeChildWindow:localAttachedWindow];
-                [localAttachedWindow orderOut:self];
-                [localAttachedWindow release];
-            });
-        });
+        [attachedWindow orderOut:self];
+        [window removeChildWindow:attachedWindow];
         attachedWindow = nil;
     }
     saveRowIndex = -1;


### PR DESCRIPTION
Opening the command sheet by clicking [+] or double-clicking a gesture, mousing over a gesture in the command sheet to show its gesture preview, and closing the sheet by pressing ESC, causes the PrefPane to crash. This is because the fade animation tries to remove the gesture preview child window from the command sheet after the command sheet has been closed.

This PR removes the fade animation responsible for the crash, and also removes it from gesture previews in the main tabs, as it wasn't being displayed. Attempts to add a background fade introduced a magenta flicker, as portions of windows with a background alpha ≤0.75 that exceed the bounds of the main window are given an opaque magenta background for security. Thus, the fade animation is being removed entirely.

This PR also reintroduces alpha=0.8 to the gesture preview window by using the correct background color (though no extra styling is included).