### PR TITLE
Add Four-Finger Tap trackpad gesture

### DIFF
--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -1412,6 +1412,62 @@ static void gestureTrackpadThreeFingerTap(const Finger *data, int nFingers, doub
 }
 
 
+static void gestureTrackpadFourFingerTap(const Finger *data, int nFingers, double timestamp) {
+    static double sttime = -1;
+    static int step = 0;
+    static double fing[4][2];
+    static int idf[4];
+    if (nFingers > 4)
+        step = 2;
+    else if (step == 0 && nFingers == 4) {
+        if (sttime == -1) {
+            sttime = timestamp;
+            step = 1;
+            trackpadClicked = 0;
+            for (int i = 0; i < 4; i++) {
+                fing[i][0] = data[i].px;
+                fing[i][1] = data[i].py;
+            }
+            // sort idf according to data[i].px + data[i].py
+            for (int i = 0; i < 4; i++)
+                idf[i] = i;
+            int i = 1, j = 1, swapvar = 0;
+            while (i < 4) {
+                j = i;
+                while (j > 0 && data[j-1].px + data[j-1].py > data[j].px + data[j].py) {
+                    swapvar = idf[j-1];
+                    idf[j-1] = idf[j];
+                    idf[j] = swapvar;
+                    j--;
+                }
+                i++;
+            }
+            for (int i = 0; i < 4; i++)
+                idf[i] = data[idf[i]].identifier;
+        }
+    } else if (step == 1) {
+        if (nFingers <= 1) {
+            if (sttime != -1 && timestamp-sttime <= clickSpeed) {
+                if (!trackpadClicked)
+                    dispatchCommand(@"Four-Finger Tap", TRACKPAD);
+            }
+            step = 0;
+            sttime = -1;
+        } else if (nFingers == 4) {
+            if (lenSqr(fing[0][0], fing[0][1], data[0].px, data[0].py) > 0.001 ||
+               lenSqr(fing[1][0], fing[1][1], data[1].px, data[1].py) > 0.001 ||
+               lenSqr(fing[2][0], fing[2][1], data[2].px, data[2].py) > 0.001 ||
+               lenSqr(fing[3][0], fing[3][1], data[3].px, data[3].py) > 0.001 ) {
+                step = 2;
+            }
+        }
+    } else if (step == 2 && nFingers <= 1) {
+        step = 0;
+        sttime  = -1;
+    }
+}
+
+
 static void gestureTrackpadOneFixOneTap(const Finger *data, int nFingers, double timestamp) {
     static double sttime = -1;
     static float fing[2][2];
@@ -1949,6 +2005,7 @@ static int trackpadCallback(int device, Finger *data, int nFingers, double times
                 gestureTrackpadOneFixOneTap(data, nFingers, timestamp);
 
                 gestureTrackpadThreeFingerTap(data, nFingers, timestamp);
+                gestureTrackpadFourFingerTap(data, nFingers, timestamp);
 
                 gestureTrackpadOneFixTwoSlide(data, nFingers, timestamp);
                 gestureTrackpadChangeSpace(data, nFingers);

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -1416,7 +1416,6 @@ static void gestureTrackpadFourFingerTap(const Finger *data, int nFingers, doubl
     static double sttime = -1;
     static int step = 0;
     static double fing[4][2];
-    static int idf[4];
     if (nFingers > 4)
         step = 2;
     else if (step == 0 && nFingers == 4) {
@@ -1428,22 +1427,6 @@ static void gestureTrackpadFourFingerTap(const Finger *data, int nFingers, doubl
                 fing[i][0] = data[i].px;
                 fing[i][1] = data[i].py;
             }
-            // sort idf according to data[i].px + data[i].py
-            for (int i = 0; i < 4; i++)
-                idf[i] = i;
-            int i = 1, j = 1, swapvar = 0;
-            while (i < 4) {
-                j = i;
-                while (j > 0 && data[j-1].px + data[j-1].py > data[j].px + data[j].py) {
-                    swapvar = idf[j-1];
-                    idf[j-1] = idf[j];
-                    idf[j] = swapvar;
-                    j--;
-                }
-                i++;
-            }
-            for (int i = 0; i < 4; i++)
-                idf[i] = data[idf[i]].identifier;
         }
     } else if (step == 1) {
         if (nFingers <= 1) {

--- a/prefpane/GesturePreviewView.m
+++ b/prefpane/GesturePreviewView.m
@@ -234,6 +234,21 @@ static void setFGx(FingerGesture *out, float x1, float y1, float x2, float y2, f
 
 }
 
+- (void)createFourFingerTap {
+    hg.n = 8;
+    hg.t = 2.5*2;
+    float s[2] = {0, 0};
+    setFG(&hg.fg[0], s[0]+0.29, s[1]+0.5, s[0]+0.29, s[1]+0.5, 0.25, 0.4);
+    setFG(&hg.fg[1], s[0]+0.43, s[1]+0.53, s[0]+0.43, s[1]+0.53, 0.25, 0.4);
+    setFG(&hg.fg[2], s[0]+0.57, s[1]+0.51, s[0]+0.57, s[1]+0.51, 0.25, 0.4);
+    setFG(&hg.fg[3], s[0]+0.71, s[1]+0.48, s[0]+0.71, s[1]+0.48, 0.25, 0.4);
+
+    setFG(&hg.fg[4], s[0]+0.29, s[1]+0.5, s[0]+0.29, s[1]+0.5, 1, 1.9);
+    setFG(&hg.fg[5], s[0]+0.43, s[1]+0.53, s[0]+0.43, s[1]+0.53, 1.5, 1.65);
+    setFG(&hg.fg[6], s[0]+0.57, s[1]+0.51, s[0]+0.57, s[1]+0.51, 1.5, 1.65);
+    setFG(&hg.fg[7], s[0]+0.71, s[1]+0.48, s[0]+0.71, s[1]+0.48, 1.5, 1.65);
+}
+
 - (void)createFourFingerClick {
     hg.n = 8;
     hg.t = 0.7*2;
@@ -1038,6 +1053,8 @@ static void setFGx(FingerGesture *out, float x1, float y1, float x2, float y2, f
             [self createThreeFingerPinchIn]; //TODO:
         } else if ([gesture isEqualToString:@"Three-Finger Pinch-Out"]) {
             [self createThreeFingerPinchOut]; //TODO:
+        } else if ([gesture isEqualToString:@"Four-Finger Tap"]) {
+            [self createFourFingerTap];
         } else if ([gesture isEqualToString:@"Four-Finger Click"]) {
             [self createFourFingerClick];
         } else if ([gesture isEqualToString:@"Index-Fix Two-Tap"]) {

--- a/prefpane/TrackpadTab.m
+++ b/prefpane/TrackpadTab.m
@@ -70,6 +70,7 @@
                    @"Three-Swipe-Down",
                    @"Three-Swipe-Left", //TODO: should tell the user that it may intefere with the OS's gestures
                    @"Three-Swipe-Right",
+                   @"Four-Finger Tap",
                    @"Four-Finger Click",
                    @"Four-Swipe-Up",
                    @"Four-Swipe-Down",


### PR DESCRIPTION
Adds a four-finger tap gesture. Because this gesture is similar to the Tab4 gestures (Index-To-Pinky/Pinky-To-Index), it will only dispatch the gesture if Tab4 has not been triggered from the same gesture.

An exception to this rule is if the four-finger tap gesture is performed as a "one-fix three-tap" gesture (see the second example animation in the four-finger tap gesture preview). In this case, if the three-tap fingers appear in the right order, a Tab4 gesture could be waiting to trigger when the last finger is raised, and the 4-tap gesture could be held up waiting to see if the Tab4 triggers or not. In order to not suspend the 4-tap gesture too long in this case, 4-tap will trigger after a delay of `clickSpeed/2`, and cancel the pending Tab4 gesture. `clickSpeed/2` is used instead of `clickSpeed` as a balance between failing to detect Tab4 gestures and delaying a one-fix three-tap too long. If the user intends to perform a Tab4 gesture, then by the time only one finger is present, they should already be in the process of raising all fingers including the last one, so we do not need to wait the full `clickSpeed` delay.

Fixes #25