### PR TITLE
Fixing 2 Bugs. jitouch now works on Ventura.

### DIFF
--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -1214,13 +1214,13 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
 
                     cursorImageType = type - 1;
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                        [cursorWindow display];
-                        [[cursorWindow contentView] setNeedsDisplay:YES];
-                        setCursorWindowAtMouse();
-                        [cursorWindow setLevel:NSScreenSaverWindowLevel];
-                        [cursorWindow makeKeyAndOrderFront:nil];
-                        [pool release];
+                        @autoreleasepool {
+                            [cursorWindow display];
+                            [[cursorWindow contentView] setNeedsDisplay:YES];
+                            setCursorWindowAtMouse();
+                            [cursorWindow setLevel:NSScreenSaverWindowLevel];
+                            [cursorWindow makeKeyAndOrderFront:nil];
+                        }
                     });
 
                     moveResizeFlag = 1;
@@ -1236,9 +1236,9 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                 CGFloat x, y;
                 getMousePosition(&x, &y);
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                    setCursorWindowAtMouse();
-                    [pool release];
+                    @autoreleasepool {
+                        setCursorWindowAtMouse();
+                    }
                 });
                 if (type == 1) {
                     setWindowPos2(cWindow, x, y, baseX, baseY, appX, appY);
@@ -1246,9 +1246,9 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                     if (!setWindowSize2(cWindow, x, y, baseX, baseY)) {
                         type = 0;
                         dispatch_async(dispatch_get_main_queue(), ^{
-                            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                            [cursorWindow orderOut:nil];
-                            [pool release];
+                            @autoreleasepool {
+                                [cursorWindow orderOut:nil];
+                            }
                         });
                         CFSafeRelease(cWindow);
                         cWindow = nil;
@@ -1291,9 +1291,9 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                 CFSafeRelease(cWindow);
                 cWindow = nil;
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                    [cursorWindow orderOut:nil];
-                    [pool release];
+                    @autoreleasepool {
+                        [cursorWindow orderOut:nil];
+                    }
                 });
 
                 moveResizeFlag = 0;
@@ -1377,9 +1377,9 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                         CFSafeRelease(cWindow);
                         cWindow = nil;
                         dispatch_async(dispatch_get_main_queue(), ^{
-                            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                            [cursorWindow orderOut:nil];
-                            [pool release];
+                            @autoreleasepool {
+                                [cursorWindow orderOut:nil];
+                            }
                         });
 
                         moveResizeFlag = 0;
@@ -2389,9 +2389,11 @@ static int gestureMagicMouseV(const Finger *data, int nFingers) {
         if (nFingers == 0 || nFingers > 2) {
             CFSafeRelease(cWindow);
             cWindow = nil;
-            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-            [cursorWindow orderOut:nil];
-            [pool release];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                @autoreleasepool {
+                    [cursorWindow orderOut:nil];
+                }
+            });
             type = 0;
             firstTouch = 1;
             reset = 0;
@@ -2406,9 +2408,11 @@ static int gestureMagicMouseV(const Finger *data, int nFingers) {
 
     if (init) {
         getMousePosition(&baseX, &baseY);
-        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-        [cursorWindow orderOut:nil];
-        [pool release];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            @autoreleasepool {
+                [cursorWindow orderOut:nil];
+            }
+        });
         if (cWindow == nil)
             cWindow = activateWindowAtPosition(baseX, baseY);
 
@@ -2418,12 +2422,15 @@ static int gestureMagicMouseV(const Finger *data, int nFingers) {
             getWindowPos(cWindow, &appX, &appY);
 
             cursorImageType = type - 1;
-            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-            [cursorWindow display];
-            setCursorWindowAtMouse();
-            [cursorWindow setLevel:NSScreenSaverWindowLevel];
-            [cursorWindow makeKeyAndOrderFront:nil];
-            [pool release];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                @autoreleasepool {
+                    [cursorWindow display];
+                    [[cursorWindow contentView] setNeedsDisplay:YES];
+                    setCursorWindowAtMouse();
+                    [cursorWindow setLevel:NSScreenSaverWindowLevel];
+                    [cursorWindow makeKeyAndOrderFront:nil];
+                }
+            });
         }
     }
     if (type) {
@@ -2437,9 +2444,11 @@ static int gestureMagicMouseV(const Finger *data, int nFingers) {
                 if (!setWindowSize2(cWindow, x, y, baseX, baseY)) {
                     CFSafeRelease(cWindow);
                     cWindow = nil;
-                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                    [cursorWindow orderOut:nil];
-                    [pool release];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        @autoreleasepool {
+                            [cursorWindow orderOut:nil];
+                        }
+                    });
                     type = 0;
                     firstTouch = 1;
                     reset = 0;

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -1200,9 +1200,9 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
             if (firstTime) {
                 getMousePosition(&baseX, &baseY);
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                    [cursorWindow orderOut:nil];
-                    [pool release];
+                    @autoreleasepool {
+                        [cursorWindow orderOut:nil];
+                    }
                 });
                 if (cWindow == nil)
                     cWindow = activateWindowAtPosition(baseX, baseY);

--- a/jitouch/Jitouch/Gesture.m
+++ b/jitouch/Jitouch/Gesture.m
@@ -1199,9 +1199,11 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
         if (step2 == 0) {
             if (firstTime) {
                 getMousePosition(&baseX, &baseY);
-                NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                [cursorWindow orderOut:nil];
-                [pool release];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+                    [cursorWindow orderOut:nil];
+                    [pool release];
+                });
                 if (cWindow == nil)
                     cWindow = activateWindowAtPosition(baseX, baseY);
 
@@ -1211,12 +1213,15 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                     getWindowPos(cWindow, &appX, &appY);
 
                     cursorImageType = type - 1;
-                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                    [cursorWindow display];
-                    setCursorWindowAtMouse();
-                    [cursorWindow setLevel:NSScreenSaverWindowLevel];
-                    [cursorWindow makeKeyAndOrderFront:nil];
-                    [pool release];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+                        [cursorWindow display];
+                        [[cursorWindow contentView] setNeedsDisplay:YES];
+                        setCursorWindowAtMouse();
+                        [cursorWindow setLevel:NSScreenSaverWindowLevel];
+                        [cursorWindow makeKeyAndOrderFront:nil];
+                        [pool release];
+                    });
 
                     moveResizeFlag = 1;
                 }
@@ -1230,15 +1235,21 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
             if (nFingers == 1 && !shouldExitMoveResize) {
                 CGFloat x, y;
                 getMousePosition(&x, &y);
-                setCursorWindowAtMouse();
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+                    setCursorWindowAtMouse();
+                    [pool release];
+                });
                 if (type == 1) {
                     setWindowPos2(cWindow, x, y, baseX, baseY, appX, appY);
                 } else if (type == 2) {
                     if (!setWindowSize2(cWindow, x, y, baseX, baseY)) {
                         type = 0;
-                        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                        [cursorWindow orderOut:nil];
-                        [pool release];
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+                            [cursorWindow orderOut:nil];
+                            [pool release];
+                        });
                         CFSafeRelease(cWindow);
                         cWindow = nil;
 
@@ -1279,9 +1290,11 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                 type = 0;
                 CFSafeRelease(cWindow);
                 cWindow = nil;
-                NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                [cursorWindow orderOut:nil];
-                [pool release];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+                    [cursorWindow orderOut:nil];
+                    [pool release];
+                });
 
                 moveResizeFlag = 0;
                 //CGEventTapEnable(eventClick, false);
@@ -1363,9 +1376,11 @@ static int gestureTrackpadMoveResize(const Finger *data, int nFingers, double ti
                         type = 0;
                         CFSafeRelease(cWindow);
                         cWindow = nil;
-                        NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-                        [cursorWindow orderOut:nil];
-                        [pool release];
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+                            [cursorWindow orderOut:nil];
+                            [pool release];
+                        });
 
                         moveResizeFlag = 0;
                     } else if (data[!min].py < fing[1][1]) {


### PR DESCRIPTION
Fix 2 bugs. It's now working on Ventura.
1. moveresize() randomly crashes because NSWindow's updates are not performed in the main queue. 
2. Move-resize icon is not changing. The new OSX seems to require contentView's setNeedsDisplay set to YES, in order to redraw.

It's been almost a decade since I last used xcode / obj-c. So, please help review the changes.
